### PR TITLE
Update D.gitignore

### DIFF
--- a/D.gitignore
+++ b/D.gitignore
@@ -18,3 +18,7 @@
 .dub
 docs.json
 __dummy.html
+docs/
+
+# Code coverage
+*.lst


### PR DESCRIPTION
**Reasons for making this change:**

Ignore default location used for documentation generation when running
```
dub build -b ddox
```
Ignore .lst files generated by coverage analysis when running
```
dub test -b unittest-cov
```

**Links to documentation supporting these rule changes:** 

The only documentation is source code itself. 

[passing output directory to ddox in dub](https://github.com/dlang/dub/blob/v0.9.25/source/dub/dub.d#L1006)

[using lst as extension of output files](https://github.com/dlang/druntime/blob/v2.071.0/src/rt/cover.d#L164)
